### PR TITLE
Feature Update and workaround for Issue #7

### DIFF
--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -77,9 +77,8 @@ function RefreshAccount (account, since)
                 local timestamp = nil
                 local pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).%d+Z"
 
-                local exchangeRates = queryExchangeRates(product_id, products)
-                if crypo_shorthandle ~= nativeCurrency and exchangeRates ~= false then
-                        price = exchangeRates["price"]
+                if crypo_shorthandle ~= nativeCurrency and productsExists(product_id, products) then
+                        price = queryExchangeRate(product_id, products)
                         -- Fetch pages of 100 orders for this currency, these are based on trades on Coinbase Pro
                         after = "start"
                         -- Iterate through pages until cb-after header is unset
@@ -180,21 +179,14 @@ function queryCoinbaseProApi(endpoint)
         return JSON(content):dictionary(), rem_headers
 end
 
-function queryExchangeRates(product_id, products)
-        for _, data in pairs(products) do
-                if data["id"] == product_id then
-                        local content = Connection():request("GET", "https://api.pro.coinbase.com/products/" .. product_id .. "/ticker")
-                        return JSON(content):dictionary()
-                end
-        end
-        return false
+function queryExchangeRate(product_id, products)
+        local content = Connection():request("GET", "https://api.pro.coinbase.com/products/" .. product_id .. "/ticker")
+        return JSON(content):dictionary()["price"]
 end
 
-function has_value (tab, val)
-        for index, value in ipairs(tab) do
-            if value == val then
-                return true
-            end
+function productsExists(product_id, products)
+        for _, data in pairs(products) do
+                if data["id"] == product_id then return true end
         end
         return false
 end


### PR DESCRIPTION
I have been using this extension for a while now and was looking for a way to include initial purchase prices made on Coinbase Pro. This change will allow MoneyMoney to display the initial purchase prices and in turn the current value best on the current price of the coin. Coins transferred to Coinbase and not traded on the market will also show, but they will not list any price information (since it's not available). For orders, it also takes into account when they were purchased and properly displays the date. For transactions I didn't bother fetching that information too.

I also took a crack at Issue #7. I couldn't think of any great solution but here is one that works: Instead of fetching the ticker information directly first compare the product_id (e.g. `BTC-EUR`) against all available products on Coinbase (`/products` endpoint.) If it's listed, try to fetch the price information too. If it's not listed, treat it as a regular currency and just display it.

The only thing I am not 100% sure about is the pagination implementation. Since orders are paginated I had to add a scraper to fetch all pages related to a `product_id`. In my tests it worked fine by using an artificial limit of `1` (the default is `100`). I would think with a really high trade volume it probably creates too many requests and takes too long, but maybe that's OK too.

Here an example:

<img width="1077" alt="screenshot 2018-11-30 at 08 27 30" src="https://user-images.githubusercontent.com/2376835/49274819-d2397080-f479-11e8-8a6e-ceb7f37347cf.png">
