### PR TITLE
[FEATURE] Fetch purchase prices when available

### DIFF
--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -165,6 +165,8 @@ function base64decode(data)
 end
 
 function queryCoinbaseProApi(endpoint)
+        -- try not to run into `too many requests`, pause before each
+        sleep(1)
         local path = string.format("/%s", endpoint)
         local timestamp = string.format("%d", MM.time())
         local apiSign = MM.hmac256(base64decode(apiSecret), timestamp .. "GET" .. path)
@@ -188,5 +190,11 @@ function productsExists(product_id, products)
                 if data["id"] == product_id then return true end
         end
         return false
+end
+
+local clock = os.clock
+function sleep(n)  -- seconds
+  local t0 = clock()
+  while clock() - t0 <= n do end
 end
 -- SIGNATURE: MCwCFFrI1B5aenRMx/jAkWnJLKRDWkq3AhQusomTlSPK5Kv7yq7HFc9PCyIXjg==

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -200,7 +200,13 @@ function queryCoinbaseProApi(endpoint)
 end
 
 function queryExchangeRate(product_id, products)
-        return queryCoinbaseProApi("products/" .. product_id .. "/ticker")["price"]
+        ticker = queryCoinbaseProApi("products/" .. product_id .. "/ticker")
+        -- sometimes newly added coins have no prices in ticket yet, then we have to use something else
+        if ticker["price"] then
+                return ticker["price"]
+        else
+                return ticker["bid"]
+        end
 end
 
 function productsExists(product_id, products)

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -180,8 +180,7 @@ function queryCoinbaseProApi(endpoint)
 end
 
 function queryExchangeRate(product_id, products)
-        local content = Connection():request("GET", "https://api.pro.coinbase.com/products/" .. product_id .. "/ticker")
-        return JSON(content):dictionary()["price"]
+        return queryCoinbaseProApi("products/" .. product_id .. "/ticker")["price"]
 end
 
 function productsExists(product_id, products)

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -97,8 +97,7 @@ function RefreshAccount (account, since)
                 local latest_timestamp = 0
                 local pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).%d+Z"
 
-                -- Ignore some FIAT currencies, focus on those being traded
-                if (crypto_shorthandle ~= "USDT" and crypto_shorthandle ~= "USDC" and crypto_shorthandle ~= nativeCurrency) and productsExists(product_id, products) then
+                if crypto_shorthandle ~= nativeCurrency and productsExists(product_id, products) then
                         price = queryExchangeRate(product_id, products)
                         -- Iterate through our orders in reverse, oldest transactions first
                         for i = #orders, 1, -1 do        
@@ -189,6 +188,7 @@ function queryCoinbaseProApi(endpoint)
         local path = string.format("/%s", endpoint)
         local timestamp = string.format("%d", MM.time())
         local apiSign = MM.hmac256(base64decode(apiSecret), timestamp .. "GET" .. path)
+
         local headers = {}
         headers["CB-ACCESS-KEY"] = apiKey
         headers["CB-ACCESS-TIMESTAMP"] = timestamp

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -26,7 +26,7 @@
 -- SOFTWARE.
 
 WebBanking {
-        version = 1.1,
+        version = 2.0,
         url = "https://api.pro.coinbase.com",
         description = "Fetch balances via Coinbase Pro API and list them as securities",
         services = { "Coinbase Pro" }

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -63,28 +63,84 @@ end
 function RefreshAccount (account, since)
         local s = {}
         local balances = queryCoinbaseProApi("accounts")
-        for key, value in pairs(balances) do
-                local balanceCurrency = value["currency"]
-                local securityCurrency = nil
-                local price = nil
+        local products = queryCoinbaseProApi("products")
+        for _, balance_data in pairs(balances) do
+                local after = nil
+                local crypo_shorthandle = balance_data["currency"]
+                local total_quantity = tonumber(balance_data["balance"])
+                local price = 1
+                local product_id = crypo_shorthandle .. "-" .. nativeCurrency
                 local amount = nil
                 local quantity = nil
-                if balanceCurrency == nativeCurrency then
-                        securityCurrency = balanceCurrency
-                        amount = value["balance"]
+                local currency = nil
+                local order_value = 0.0
+                local timestamp = nil
+                local pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).%d+Z"
+
+                if crypo_shorthandle ~= nativeCurrency and productsExists(product_id, products) then
+                        price = queryExchangeRate(product_id, products)
+                        -- Fetch pages of 100 orders for this currency, these are based on trades on Coinbase Pro
+                        after = "start"
+                        -- Iterate through pages until cb-after header is unset
+                        while after ~= nil do
+                                if after == "start" then
+                                        orders, headers = queryCoinbaseProApi("orders?&status=done&&product_id=" .. product_id)
+                                else
+                                        orders, headers = queryCoinbaseProApi("orders?after=" .. after .. "&status=done&product_id=" .. product_id)
+                                end
+                                -- Set our next page to cb-after header
+                                after = headers["cb-after"]
+
+                                -- Iterate through this page of orders
+                                for _, order_data in pairs(orders) do
+                                        -- We only care of buy, sold coins will not be in our balance anymore
+                                        if order_data["side"] == "buy" then
+                                                year, month, day, hour, min, sec = order_data["done_at"]:match(pattern)
+                                                timestamp = os.time({day=day,month=month,year=year,hour=hour,min=min,sec=sec})
+                                                quantity = order_data["filled_size"]
+                                                -- We deduct our trade from the total amount
+                                                total_quantity = total_quantity - quantity
+                                                if order_data["price"] ~= nil then
+                                                        order_value = order_data["price"]
+                                                else
+                                                        order_value = 1 / order_data["filled_size"] * order_data["executed_value"]
+                                                end
+                                                s[#s+1] = {
+                                                        tradeTimestamp = timestamp,
+                                                        name = crypo_shorthandle,
+                                                        market = market,
+                                                        quantity = quantity,
+                                                        currency = currency,
+                                                        price = price,
+                                                        purchasePrice = order_value,
+                                                        amount = quantity * price
+                                                }
+                                        end
+                                end
+                        end
+                        -- Sums for the remaining coins not in the order book
+                        quantity = total_quantity
+                        amount = total_quantity * price
                 else
-                        local exchangeRates = queryExchangeRates(balanceCurrency)
-                        price = exchangeRates["price"]
-                        quantity = value["balance"]
+                        -- A native currency, not a crypto coin
+                        quantity = nil
+                        price = nil
+                        currency = nativeCurrency
+                        amount = total_quantity
                 end
-                s[#s+1] = {
-                        name = value["currency"],
-                        market = market,
-                        currency = securityCurrency,
-                        quantity = quantity,
-                        price = price,
-                        amount = amount
-                }
+                -- We also have to add our remaining total amount that is not part of trades
+                -- Could come from deposits of other accounts, there will be no value attached to the transfer
+                -- Only add them if we have some left after removing trades
+                if total_quantity > 0 then
+                        s[#s+1] = {
+                                name = crypo_shorthandle,
+                                market = market,
+                                currency = currency,
+                                quantity = quantity,
+                                price = price,
+                                amount = amount
+                        }
+                end
         end
         return {securities = s}
 end
@@ -119,14 +175,19 @@ function queryCoinbaseProApi(endpoint)
         headers["CB-ACCESS-SIGN"] = MM.base64(apiSign)
         headers["CB-ACCESS-PASSPHRASE"] = apiPassphrase
 
-        local content = Connection():request("GET", url .. path, nil, nil, headers)
-        return JSON(content):dictionary()
+        content, charset, mimeType, filename, rem_headers = Connection():request("GET", url .. path, nil, nil, headers)
+        return JSON(content):dictionary(), rem_headers
 end
 
-function queryExchangeRates(currency)
-        local url = string.format("https://api.pro.coinbase.com/products/%s-%s/ticker", currency, nativeCurrency)
-        local content = Connection():request("GET", url)
-        return JSON(content):dictionary()
+function queryExchangeRate(product_id, products)
+        local content = Connection():request("GET", "https://api.pro.coinbase.com/products/" .. product_id .. "/ticker")
+        return JSON(content):dictionary()["price"]
 end
 
+function productsExists(product_id, products)
+        for _, data in pairs(products) do
+                if data["id"] == product_id then return true end
+        end
+        return false
+end
 -- SIGNATURE: MCwCFFrI1B5aenRMx/jAkWnJLKRDWkq3AhQusomTlSPK5Kv7yq7HFc9PCyIXjg==

--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -97,7 +97,8 @@ function RefreshAccount (account, since)
                 local latest_timestamp = 0
                 local pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+).%d+Z"
 
-                if crypto_shorthandle ~= nativeCurrency and productsExists(product_id, products) then
+                -- Ignore some FIAT currencies, focus on those being traded
+                if (crypto_shorthandle ~= "USDT" and crypto_shorthandle ~= "USDC" and crypto_shorthandle ~= nativeCurrency) and productsExists(product_id, products) then
                         price = queryExchangeRate(product_id, products)
                         -- Iterate through our orders in reverse, oldest transactions first
                         for i = #orders, 1, -1 do        
@@ -188,7 +189,6 @@ function queryCoinbaseProApi(endpoint)
         local path = string.format("/%s", endpoint)
         local timestamp = string.format("%d", MM.time())
         local apiSign = MM.hmac256(base64decode(apiSecret), timestamp .. "GET" .. path)
-
         local headers = {}
         headers["CB-ACCESS-KEY"] = apiKey
         headers["CB-ACCESS-TIMESTAMP"] = timestamp


### PR DESCRIPTION
I have been using this extension for a while now and was looking for a way to include initial purchase prices made on Coinbase Pro. This change will allow MoneyMoney to display the initial purchase prices and in turn the current value best on the current price of the coin. Coins transferred to Coinbase and not traded on the market will also show, but they will not list any price information (since it's not available). For orders, it also takes into account when they were purchased and properly displays the date. For transactions I didn't bother fetching that information too.

The only thing I am not 100% sure about is the pagination implementation. Since orders are paginated I had to add a scraper to fetch all pages related to a product_id. In my tests it worked fine by using an artificial limit of 1 (the default is 100). I would think with a really high trade volume it probably creates too many requests and takes too long, but maybe that's OK too.

Here an example:

<img width="1077" alt="screenshot 2018-11-30 at 08 27 30" src="https://user-images.githubusercontent.com/2376835/49285355-7e3d8480-f497-11e8-9c5f-02797bf8e850.png">

This PR already incorporates the fix for currencies missing ticker information.