### PR TITLE
workaround: hardcode removed XRP support. 

### DIFF
--- a/Coinbase Pro.lua
+++ b/Coinbase Pro.lua
@@ -66,6 +66,9 @@ function RefreshAccount (account, since)
         local products = queryCoinbaseProApi("products")
         for key, value in pairs(balances) do
                 local balanceCurrency = value["currency"]
+                if balanceCurrency == "XRP" then
+                        goto continue
+                end
                 local securityCurrency = nil
                 local price = nil
                 local amount = nil
@@ -92,6 +95,8 @@ function RefreshAccount (account, since)
                                 }
                         end
                 end
+
+                ::continue::
         end
         return {securities = s}
 end


### PR DESCRIPTION
Trading with XRP is paused, but it is still listed on coinbase.
Hence the coin is available but the subsequent request queryExchangeRate products/"XRP"/ticker fails.
This is a lazy workaround, one could investigate this further.
Also it would be nice if the requests could be run in parallel and if there were options to disable coins, because the fetch is really slow with a lot of coins.